### PR TITLE
Possible fix for elements that are left visible

### DIFF
--- a/assets/css/paysoncheckout.css
+++ b/assets/css/paysoncheckout.css
@@ -4,8 +4,9 @@
 .woo-shipping,
 .woo-billing,
 .checkout-sidebar,
+.checkout-row,
 .order-review {
-	display: none;
+	display: none !important;
 }
 
 .paysoncheckout-deselected #customer_details,
@@ -15,7 +16,11 @@
 .paysoncheckout-deselected .woo-billing,
 .paysoncheckout-deselected .checkout-sidebar,
 .paysoncheckout-deselected .order-review {
-	display: block;
+	display: block !important;
+}
+
+.paysoncheckout-deselected .checkout-row {
+	display: table !important;
 }
 
 .paysoncheckout-selected .woocommerce {


### PR DESCRIPTION
Not all elements were hidden when selecting Payson as payment method, which caused the browser to display a big gray box above the checkout cart contents.

Now, I'm not a web developer so I'm not sure if `!important` is the correct way to do it. The reason I added it was because Woocommerce's own stylesheets had a more specific rule for the element.