### PR TITLE
1.3.1

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -37,6 +37,11 @@ More information on how to get started can be found in the [plugin documentation
 
 == CHANGELOG ==
 
+= 2018.05.15    - version 1.3.1 =
+* Tweak			- Only make merchant account validation request to Payson on PaysonCheckout 2.0 settings page.
+* Fix			- Don’t display Payson as an available payment method if cart total is too low (below 4 SEK or 0 EUR).
+* Fix			- Save customer order note correctly when processing WC checkout/order.
+
 = 2018.05.04    - version 1.3.0 =
 * Feature       - Added support for handling payments of manually created orders (via Pay for order page).
 * Tweak         - Save _payson_checkout_id to WC order in thank you page if it hasn't been saved earlier. 

--- a/assets/js/paysoncheckout.js
+++ b/assets/js/paysoncheckout.js
@@ -340,11 +340,11 @@
 				if(data.data.customer_data.shippingAddress2 != null) {
 					datastring = datastring + '&shipping_address_2=' + data.data.customer_data.shippingAddress2;
 				}
-                /*
+                
                 if(data.data.order_note != 'undefined'){
                     datastring = datastring + '&order_comments=' + data.data.order_note;
                 }
-				*/
+				
                     jQuery.ajax({
                     type: 'POST',
                     url: wc_checkout_params.checkout_url,

--- a/includes/class-wc-paysoncheckout-admin-notices.php
+++ b/includes/class-wc-paysoncheckout-admin-notices.php
@@ -54,7 +54,7 @@ class WC_PaysonCheckout_Admin_Notices {
 	 * Validate entered Payson credentials
 	 */
 	public function validate_account() {
-		if ( 'yes' != $this->enabled ) {
+		if ( 'yes' != $this->enabled || 'paysoncheckout' != $_GET['section'] ) {
 			return;
 		}
 		// Account check

--- a/includes/class-wc-paysoncheckout-ajax.php
+++ b/includes/class-wc-paysoncheckout-ajax.php
@@ -213,6 +213,11 @@ class WC_PaysonCheckout_Ajax {
 			$return = array();
 			$return['customer_data'] = self::verify_customer_data( $checkout );
 			$return['nonce'] = wp_create_nonce( 'woocommerce-process_checkout' );
+			if ( null != WC()->session->get( 'payson_customer_order_note' ) ) {
+				$return['order_note'] = WC()->session->get( 'payson_customer_order_note' );
+			} else {
+				$return['order_note'] = '';
+			}
 			$shipping_methods = WC()->session->get( 'chosen_shipping_methods' );
 			$return['shipping'] = $shipping_methods[0];
 			

--- a/includes/class-wc-paysoncheckout-ajax.php
+++ b/includes/class-wc-paysoncheckout-ajax.php
@@ -167,6 +167,14 @@ class WC_PaysonCheckout_Ajax {
 		WC()->cart->calculate_fees();
 		WC()->cart->calculate_totals();
 
+		// If update checkout changed cart total to below 4 SEK or 0 EUR reload the checkout page
+		if( ( WC()->cart->total < 4 && 'SEK' == get_woocommerce_currency() ) ||  WC()->cart->total == 0 && 'EUR' == get_woocommerce_currency() ) {
+			$return = array();
+			$return['redirect_url'] = wc_get_checkout_url();
+			wp_send_json_error( $return );
+			wp_die();
+		}
+
 		$wc_order = new WC_PaysonCheckout_WC_Order();
 		$order_id = $wc_order->update_or_create_local_order();
 

--- a/includes/gateways/class-wc-paysoncheckout-gateway.php
+++ b/includes/gateways/class-wc-paysoncheckout-gateway.php
@@ -102,6 +102,13 @@ function init_wc_gateway_paysoncheckout_class() {
 					if ( ! $this->merchant_id || ! $this->api_key ) {
 						return false;
 					}
+					// Don't display the payment method if we have an order with to low amount
+					if( WC()->cart->total < 4 && 'SEK' == get_woocommerce_currency() ) {
+						return false;
+					}
+					if( WC()->cart->total == 0 && 'EUR' == get_woocommerce_currency() ) {
+						return false;
+					}
 				}
 
 				return true;

--- a/paysoncheckout-for-woocommerce.php
+++ b/paysoncheckout-for-woocommerce.php
@@ -3,7 +3,7 @@
  * Plugin Name:     PaysonCheckout 2.0 for WooCommerce
  * Plugin URI:      http://krokedil.com/
  * Description:     Provides a PaysonCheckout 2.0 payment gateway for WooCommerce.
- * Version:         1.3.0
+ * Version:         1.3.1
  * Author:          Krokedil
  * Author URI:      http://krokedil.com/
  * Developer:       Krokedil
@@ -25,7 +25,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 load_plugin_textdomain( 'woocommerce-gateway-paysoncheckout', false, dirname( plugin_basename( __FILE__ ) ) . '/languages/' );
 
 // Define plugin constants.
-define( 'PAYSONCHECKOUT_VERSION', '1.3.0' );
+define( 'PAYSONCHECKOUT_VERSION', '1.3.1' );
 define( 'PAYSONCHECKOUT_URL', untrailingslashit( plugins_url( '/', __FILE__ ) ) );
 define( 'PAYSONCHECKOUT_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 


### PR DESCRIPTION
* Tweak - Only make merchant account validation request to Payson on PaysonCheckout 2.0 settings page.
* Fix - Don’t display Payson as an available payment method if cart total is too low (below 4 SEK or 0 EUR).
* Fix	- Save customer order note correctly when processing WC checkout/order.