### PR TITLE
1.4.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .idea/workspace.xml
 .idea/vcs.xml
 .idea/paysoncheckout-for-woocommerce.iml
+SyncToy_8bf1c734-e693-4692-b537-c790e6978d41.dat

--- a/README.txt
+++ b/README.txt
@@ -1,10 +1,10 @@
 === PaysonCheckout 2.0 for WooCommerce ===
 Contributors: krokedil, niklashogefjord
 Tags: ecommerce, e-commerce, woocommerce, payson, paysoncheckout2.0
-Requires at least: 4.3
-Tested up to: 4.9.5
+Requires at least: 4.5
+Tested up to: 4.9.8
 WC requires at least: 3.0
-WC tested up to: 3.3.5
+WC tested up to: 3.4.6
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 Stable tag: trunk
@@ -36,6 +36,15 @@ More information on how to get started can be found in the [plugin documentation
 
 
 == CHANGELOG ==
+
+= 2018.10.16    - version 1.4.0 =
+* Feature		- Added support for wp_add_privacy_policy_content (for GDPR compliance). More info: https://core.trac.wordpress.org/attachment/ticket/43473/PRIVACY-POLICY-CONTENT-HOOK.md.
+* Tweak			- Improved error messaging in Payson account check request.
+* Fix			- Updated compatability functions to prevent error.
+* Tweak			- Added filters payson_pay_data, payson_gui & payson_customer to allow merchants to modify order data sent to Payson.
+* Tweak			- Added company name to WooCommerce order if purchase is a B2B order.
+* Fix			- Changed how JS eventlistener PaysonEmbeddedAddressChanged was implemented. Some websites was not able to retrieve customer address data.
+* Fix			- Submission failure process bug fix. Order is now created in Woo and customer redirected to thankyou page even if original checkout form submission fails.
 
 = 2018.05.15    - version 1.3.1 =
 * Tweak			- Only make merchant account validation request to Payson on PaysonCheckout 2.0 settings page.

--- a/assets/js/paysoncheckout.js
+++ b/assets/js/paysoncheckout.js
@@ -340,6 +340,11 @@
 				if(data.data.customer_data.shippingAddress2 != null) {
 					datastring = datastring + '&shipping_address_2=' + data.data.customer_data.shippingAddress2;
 				}
+
+				if(data.data.customer_data.type == 'business') {
+					datastring = datastring + '&billing_company=' + data.data.customer_data.billingFirstName;
+					datastring = datastring + '&shipping_company=' + data.data.customer_data.shippingFirstName;
+				}
                 
                 if(data.data.order_note != 'undefined'){
                     datastring = datastring + '&order_comments=' + data.data.order_note;

--- a/assets/js/paysoncheckout.js
+++ b/assets/js/paysoncheckout.js
@@ -217,7 +217,7 @@
 	});
 	
 	// When Address update event is triggered
-	$(document).on('PaysonEmbeddedAddressChanged', function(data) {
+	document.addEventListener("PaysonEmbeddedAddressChanged",function(data) {
 		var should_update = false;
 
 		// Don't update if we're on a pay for order page
@@ -278,7 +278,7 @@
 		);
 	});
 
-	$(document).on('PaysonEmbeddedCheckoutResult', function(data) {
+	document.addEventListener("PaysonEmbeddedCheckoutResult",function(data) {
 		if ('yes' === wc_paysoncheckout.debug) {
 			console.log('PaysonEmbeddedCheckoutResult', data);
 		}

--- a/assets/js/paysoncheckout.js
+++ b/assets/js/paysoncheckout.js
@@ -403,7 +403,7 @@
 
 	function checkout_error() {
 		console.log('checkout error');
-		if ("paysoncheckout" === $("input[name='payment_method']:checked").val()) {
+		if ( wc_paysoncheckout.payment_successful == '1') {
 			$.ajax(
 	            wc_paysoncheckout.ajax_url,
 	            {

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,19 @@
 *** PaysonCheckout 2.0 Changelog ***
 
+2018.10.16    	- version 1.4.0
+* Feature		- Added support for wp_add_privacy_policy_content (for GDPR compliance). More info: https://core.trac.wordpress.org/attachment/ticket/43473/PRIVACY-POLICY-CONTENT-HOOK.md.
+* Tweak			- Improved error messaging in Payson account check request.
+* Fix			- Updated compatability functions to prevent error.
+* Tweak			- Added filters payson_pay_data, payson_gui & payson_customer to allow merchants to modify order data sent to Payson.
+* Tweak			- Added company name to WooCommerce order if purchase is a B2B order.
+* Fix			- Changed how JS eventlistener PaysonEmbeddedAddressChanged was implemented. Some websites was not able to retrieve customer address data.
+* Fix			- Submission failure process bug fix. Order is now created in Woo and customer redirected to thankyou page even if original checkout form submission fails.
+
+= 2018.05.15    - version 1.3.1 =
+* Tweak			- Only make merchant account validation request to Payson on PaysonCheckout 2.0 settings page.
+* Fix			- Don’t display Payson as an available payment method if cart total is too low (below 4 SEK or 0 EUR).
+* Fix			- Save customer order note correctly when processing WC checkout/order.
+
 2018.05.04    	- version 1.3.0
 * Feature       - Added support for handling payments of manually created orders (via Pay for order page).
 * Tweak         - Save _payson_checkout_id to WC order in thank you page if it hasn't been saved earlier. 

--- a/includes/class-wc-paysoncheckout-ajax.php
+++ b/includes/class-wc-paysoncheckout-ajax.php
@@ -239,14 +239,14 @@ class WC_PaysonCheckout_Ajax {
 	}
 
 	public function verify_customer_data( $checkout ) {
-		$billing_first_name     = isset( $checkout->customer->firstName ) ? $checkout->customer->firstName : '.';
-		$billing_last_name      = isset( $checkout->customer->lastName ) ? $checkout->customer->lastName : '.';
-		$billing_address     = isset( $checkout->customer->street ) ? $checkout->customer->street : '.';
-		$billing_postal_code      = isset( $checkout->customer->postalCode ) ? $checkout->customer->postalCode : '11111';
-		$billing_city     = isset( $checkout->customer->city ) ? $checkout->customer->city : '.';
-		$billing_country      = isset( $checkout->customer->countryCode ) ? $checkout->customer->countryCode : '.';
-		$billing_phone      = isset( $checkout->customer->phone ) ? $checkout->customer->phone : '';
-		$billing_email      = isset( $checkout->customer->email ) ? $checkout->customer->email : 'test@test.se';
+		$billing_first_name		= isset( $checkout->customer->firstName ) ? $checkout->customer->firstName : '.';
+		$billing_last_name		= !empty( $checkout->customer->lastName ) ? $checkout->customer->lastName : '.';
+		$billing_address		= isset( $checkout->customer->street ) ? $checkout->customer->street : '.';
+		$billing_postal_code	= isset( $checkout->customer->postalCode ) ? $checkout->customer->postalCode : '11111';
+		$billing_city     		= isset( $checkout->customer->city ) ? $checkout->customer->city : '.';
+		$billing_country		= isset( $checkout->customer->countryCode ) ? $checkout->customer->countryCode : '.';
+		$billing_phone			= isset( $checkout->customer->phone ) ? $checkout->customer->phone : '';
+		$billing_email			= isset( $checkout->customer->email ) ? $checkout->customer->email : 'test@test.se';
 
 		$customer_information = array(
 			'billingFirstName'      =>  $billing_first_name,

--- a/includes/class-wc-paysoncheckout-ajax.php
+++ b/includes/class-wc-paysoncheckout-ajax.php
@@ -254,15 +254,16 @@ class WC_PaysonCheckout_Ajax {
 			'billingAddress'        =>  $billing_address,
 			'billingPostalCode'     =>  $billing_postal_code,
 			'billingCity'           =>  $billing_city,
-			'billingCounry'           =>  $billing_country,
+			'billingCounry'			=>  $billing_country,
 			'shippingFirstName'     =>  $billing_first_name,
 			'shippingLastName'      =>  $billing_last_name,
 			'shippingAddress'       =>  $billing_address,
 			'shippingPostalCode'    =>  $billing_postal_code,
 			'shippingCity'          =>  $billing_city,
-			'shippingCounry'           =>  $billing_country,
+			'shippingCounry'		=>  $billing_country,
 			'phone'                 =>  $billing_phone,
 			'email'                 =>  $billing_email,
+			'type'                 	=>  $checkout->customer->type,
 		);
 		return $customer_information;
 	}

--- a/includes/class-wc-paysoncheckout-gdpr.php
+++ b/includes/class-wc-paysoncheckout-gdpr.php
@@ -1,0 +1,43 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+/**
+ * Compliance with European Union's General Data Protection Regulation.
+ *
+ * @class    WC_PaysonCheckout_GDPR
+ * @version  1.0.0
+ * @package  WC_PaysonCheckout/includes
+ * @category Class
+ * @author   Krokedil
+ */
+class WC_PaysonCheckout_GDPR {
+	/**
+	 * Class constructor.
+	 */
+	public function __construct() {
+		add_action( 'admin_init', array( $this, 'privacy_declarations' ) );
+	}
+	/**
+	 * Privacy declarations.
+	 *
+	 * @return void
+	 */
+	public function privacy_declarations() {
+		if ( function_exists( 'wp_add_privacy_policy_content' ) ) {
+			$content =
+				__(
+					'When you place an order in the webstore with Payson as the choosen payment method, ' .
+					'information about the products in the order (namne, price, quantity, SKU) is sent to Payson. ' .
+					'When the purchase is finalized Payson sends your billing and shipping address back to the webstore. ' .
+					'This data plus an unique identifier for the purchase is then stored as billing and shipping data in the order in WooCommerce.',
+					'woocommerce-gateway-paysoncheckout'
+				);
+			wp_add_privacy_policy_content(
+				'PaysonCheckout for WooCommerce',
+				wp_kses_post( wpautop( $content ) )
+			);
+		}
+	}
+}
+new WC_PaysonCheckout_GDPR();

--- a/includes/class-wc-paysoncheckout-setup-payson-api.php
+++ b/includes/class-wc-paysoncheckout-setup-payson-api.php
@@ -283,7 +283,8 @@ class WC_PaysonCheckout_Setup_Payson_API {
 
 			return $account;
 		} catch ( Exception $ex ) {
-			return new WP_Error( 'error', __( 'The entered Payson Merchant ID, API Key or test/live mode is not correct.', 'woocommerce-gateway-paysoncheckout' ) );
+			WC_Gateway_PaysonCheckout::log( 'Validate account error: ' . $ex->getMessage() . '. Merchant id: ' . $merchant_id . '. API-key: ' . $api_key . '. Testmode: ' . $this->settings['testmode'] );
+			return new WP_Error( 'error', __( 'The entered Payson Merchant ID, API Key or test/live mode is not correct. Returned respons from Payson: ' . $ex->getMessage(), 'woocommerce-gateway-paysoncheckout' ) );
 		}
 	}
 

--- a/includes/class-wc-paysoncheckout-setup-payson-api.php
+++ b/includes/class-wc-paysoncheckout-setup-payson-api.php
@@ -30,14 +30,13 @@ class WC_PaysonCheckout_Setup_Payson_API {
 	 * @return mixed|null|\PaysonEmbedded\Checkout
 	 */
 	public function get_checkout( $order_id = false ) {
-		//require_once PAYSONCHECKOUT_PATH . '/includes/lib/paysonapi.php';
-
+		// require_once PAYSONCHECKOUT_PATH . '/includes/lib/paysonapi.php';
 		// Setup.
 		$callPaysonApi  = $this->set_payson_api();
 		$paysonMerchant = $this->set_merchant( $order_id );
-		$payData        = $this->set_pay_data( $order_id );
-		$gui            = $this->set_gui();
-		$customer       = $this->set_customer();
+		$payData        = apply_filters( 'payson_pay_data', $this->set_pay_data() );
+		$gui            = apply_filters( 'payson_gui', $this->set_gui() );
+		$customer       = apply_filters( 'payson_customer', $this->set_customer() );
 		$checkout       = new PaysonEmbedded\Checkout( $paysonMerchant, $payData, $gui, $customer );
 
 		/*
@@ -53,9 +52,9 @@ class WC_PaysonCheckout_Setup_Payson_API {
 				WC()->session->__unset( 'payson_checkout_id' );
 			}
 			$payson_embedded_status = $checkout_temp_obj->status;
-			
+
 			// Unset the payson_checkout_id session and create a new one if the currency hs been changed
-			if( strtoupper($checkout_temp_obj->payData->currency) !== get_woocommerce_currency() ) {
+			if ( strtoupper( $checkout_temp_obj->payData->currency ) !== get_woocommerce_currency() ) {
 				update_post_meta( $order_id, '_order_currency', get_woocommerce_currency() );
 				WC()->session->__unset( 'payson_checkout_id' );
 			}
@@ -64,19 +63,30 @@ class WC_PaysonCheckout_Setup_Payson_API {
 			// Update checkout (if reloading checkout page when a payson_checkout_id session exist).
 			$checkout_temp_obj->payData = $this->set_pay_data( $order_id );
 
-			// Check if this is an pay for order or a regular purchase 
+			// Check if this is an pay for order or a regular purchase
 			if ( isset( $_GET['pay_for_order'], $_GET['key'] ) ) {
-				$order = wc_get_order( $order_id );
-				$confirmationUri = add_query_arg( array( 'pay_for_order' =>'true', 'paysonorder' => $checkout_temp_obj->id ), $order->get_checkout_order_received_url() );
+				$order           = wc_get_order( $order_id );
+				$confirmationUri = add_query_arg(
+					array(
+						'pay_for_order' => 'true',
+						'paysonorder'   => $checkout_temp_obj->id,
+					), $order->get_checkout_order_received_url()
+				);
 			} else {
-				$confirmationUri = add_query_arg( array( 'payson_payment_successful' =>'1', 'wc_order' => $order_id, 'paysonorder' => $checkout_temp_obj->id ), wc_get_checkout_url() );
+				$confirmationUri = add_query_arg(
+					array(
+						'payson_payment_successful' => '1',
+						'wc_order'                  => $order_id,
+						'paysonorder'               => $checkout_temp_obj->id,
+					), wc_get_checkout_url()
+				);
 			}
 			$checkout_temp_obj->merchant->confirmationUri = $confirmationUri;
 
 			WC_Gateway_PaysonCheckout::log( 'Update checkout call sent to Payson (in get_checkout() function): ' . stripslashes_deep( json_encode( $checkout_temp_obj ) ) );
-			
+
 			try {
-				$checkout_temp_obj          = $callPaysonApi->UpdateCheckout( $checkout_temp_obj );
+				$checkout_temp_obj = $callPaysonApi->UpdateCheckout( $checkout_temp_obj );
 			} catch ( Exception $e ) {
 				WC_Gateway_PaysonCheckout::log( 'Update checkout error response from Payson: ' . stripslashes_deep( json_encode( $e->getMessage() ) ) );
 				WC()->session->__unset( 'payson_checkout_id' );
@@ -85,7 +95,7 @@ class WC_PaysonCheckout_Setup_Payson_API {
 		} else {
 			// Create checkout
 			WC_Gateway_PaysonCheckout::log( 'Create checkout call sent to Payson: ' . stripslashes_deep( json_encode( $checkout ) ) );
-			
+
 			try {
 				$checkoutId = $callPaysonApi->CreateCheckout( $checkout );
 			} catch ( Exception $e ) {
@@ -93,18 +103,29 @@ class WC_PaysonCheckout_Setup_Payson_API {
 				WC()->session->__unset( 'payson_checkout_id' );
 				return new WP_Error( 'connection-error', $e->getMessage() );
 			}
-			
+
 			$checkout_temp_obj = $callPaysonApi->GetCheckout( $checkoutId );
 			WC_Gateway_PaysonCheckout::log( 'Create checkout response from Payson: ' . stripslashes_deep( json_encode( $checkout_temp_obj ) ) );
-			
-			// Check if this is an pay for order or a regular purchase 
+
+			// Check if this is an pay for order or a regular purchase
 			if ( isset( $_GET['pay_for_order'], $_GET['key'] ) ) {
-				$order = wc_get_order( $order_id );
-				$confirmationUri = add_query_arg( array( 'pay_for_order' =>'true', 'paysonorder' => $checkout_temp_obj->id ), $order->get_checkout_order_received_url() );
+				$order           = wc_get_order( $order_id );
+				$confirmationUri = add_query_arg(
+					array(
+						'pay_for_order' => 'true',
+						'paysonorder'   => $checkout_temp_obj->id,
+					), $order->get_checkout_order_received_url()
+				);
 			} else {
-				$confirmationUri = add_query_arg( array( 'payson_payment_successful' =>'1', 'wc_order' => $order_id, 'paysonorder' => $checkout_temp_obj->id ), wc_get_checkout_url() );
+				$confirmationUri = add_query_arg(
+					array(
+						'payson_payment_successful' => '1',
+						'wc_order'                  => $order_id,
+						'paysonorder'               => $checkout_temp_obj->id,
+					), wc_get_checkout_url()
+				);
 			}
-			
+
 			$checkout_temp_obj->merchant->confirmationUri = $confirmationUri;
 			$checkout_temp_obj                            = $callPaysonApi->UpdateCheckout( $checkout_temp_obj );
 
@@ -125,11 +146,11 @@ class WC_PaysonCheckout_Setup_Payson_API {
 		// Setup.
 		$callPaysonApi  = $this->set_payson_api();
 		$paysonMerchant = $this->set_merchant( $order_id );
-		$payData        = $this->set_pay_data( $order_id );
-		$gui            = $this->set_gui();
-		$customer       = $this->set_customer();
+		$payData        = apply_filters( 'payson_pay_data', $this->set_pay_data() );
+		$gui            = apply_filters( 'payson_gui', $this->set_gui() );
+		$customer       = apply_filters( 'payson_customer', $this->set_customer() );
 		$checkout       = new PaysonEmbedded\Checkout( $paysonMerchant, $payData, $gui, $customer );
-		
+
 		$payson_embedded_status = '';
 		$checkout_temp_obj      = null;
 		if ( WC()->session->get( 'payson_checkout_id' ) ) {
@@ -141,9 +162,9 @@ class WC_PaysonCheckout_Setup_Payson_API {
 				return new WP_Error( 'connection-error', $e->getMessage() );
 			}
 			$payson_embedded_status = $checkout_temp_obj->status;
-			
+
 			// Unset the payson_checkout_id session and return error if the currency hs been changed
-			if( strtoupper($checkout_temp_obj->payData->currency) !== get_woocommerce_currency() ) {
+			if ( strtoupper( $checkout_temp_obj->payData->currency ) !== get_woocommerce_currency() ) {
 				update_post_meta( $order_id, '_order_currency', get_woocommerce_currency() );
 				WC()->session->__unset( 'payson_checkout_id' );
 				return new WP_Error( 'order-error', 'Currency mismatch' );
@@ -152,17 +173,22 @@ class WC_PaysonCheckout_Setup_Payson_API {
 		if ( WC()->session->get( 'payson_checkout_id' ) && ( 'readyToPay' === $payson_embedded_status || 'created' === $payson_embedded_status ) ) {
 			// Update checkout.
 			$checkout_temp_obj->payData = $this->set_pay_data( $order_id );
-			
+
 			// Update notification url with the Payson Checkout ID
-			$confirmationUri = add_query_arg( array( 'payson_payment_successful' =>'1', 'wc_order' => $order_id ), wc_get_checkout_url() );
+			$confirmationUri                              = add_query_arg(
+				array(
+					'payson_payment_successful' => '1',
+					'wc_order'                  => $order_id,
+				), wc_get_checkout_url()
+			);
 			$confirmationUri                              = add_query_arg( array( 'paysonorder' => $checkout_temp_obj->id ), $confirmationUri );
 			$checkout_temp_obj->merchant->confirmationUri = $confirmationUri;
-			
+
 			WC_Gateway_PaysonCheckout::log( 'Update checkout call sent to Payson: ' . stripslashes_deep( json_encode( $checkout_temp_obj ) ) );
-			$checkout_temp_obj          = $callPaysonApi->UpdateCheckout( $checkout_temp_obj );
+			$checkout_temp_obj = $callPaysonApi->UpdateCheckout( $checkout_temp_obj );
 			// @todo - check that the update request was ok
 			return $checkout_temp_obj;
-			
+
 		} else {
 
 			WC_Gateway_PaysonCheckout::log( 'Something was wrong with the status in update_checkout request: ' . stripslashes_deep( json_encode( $checkout_temp_obj ) ) );
@@ -172,48 +198,53 @@ class WC_PaysonCheckout_Setup_Payson_API {
 	}
 
 	public function set_payson_api() {
-		//require_once PAYSONCHECKOUT_PATH . '/includes/lib/paysonapi.php';
+		// require_once PAYSONCHECKOUT_PATH . '/includes/lib/paysonapi.php';
 		// Your merchant ID and apikey. Information about the merchant and the integration.
-		$environment = ( 'yes' == $this->settings['testmode'] ) ? true : false;
-		$merchant_id = $this->settings['merchant_id'];
-		$api_key     = $this->settings['api_key'];
+		$environment   = ( 'yes' == $this->settings['testmode'] ) ? true : false;
+		$merchant_id   = $this->settings['merchant_id'];
+		$api_key       = $this->settings['api_key'];
 		$callPaysonApi = new PaysonEmbedded\PaysonApi( $merchant_id, $api_key, $environment );
 
 		return $callPaysonApi;
 	}
 
 	public function set_merchant( $order_id ) {
-		//require_once PAYSONCHECKOUT_PATH . '/includes/lib/paysonapi.php';
+		// require_once PAYSONCHECKOUT_PATH . '/includes/lib/paysonapi.php';
 		// URLs used by payson for redirection after a completed/canceled/notification purchase.
 		$order = wc_get_order( $order_id );
 
-		// Check if this is an pay for order or a regular purchase 
+		// Check if this is an pay for order or a regular purchase
 		if ( isset( $_GET['pay_for_order'], $_GET['key'] ) ) {
-			$confirmationUri = add_query_arg( array( 'pay_for_order' =>'true' ), $order->get_checkout_order_received_url() );
+			$confirmationUri = add_query_arg( array( 'pay_for_order' => 'true' ), $order->get_checkout_order_received_url() );
 		} else {
-			$confirmationUri = add_query_arg( array( 'payson_payment_successful' =>'1', 'wc_order' => $order_id ), wc_get_checkout_url() );
+			$confirmationUri = add_query_arg(
+				array(
+					'payson_payment_successful' => '1',
+					'wc_order'                  => $order_id,
+				), wc_get_checkout_url()
+			);
 		}
-		
+
 		$checkoutUri     = wc_get_checkout_url();
 		$notificationUri = add_query_arg( 'wc_order', $order_id, get_home_url() . '/wc-api/WC_Gateway_PaysonCheckout/' );
 		$termsUri        = wc_get_page_permalink( 'terms' );
 		$partnerId       = 'Krokedil';
 		$reference       = $order->get_order_number();
-		$paysonMerchant = new PaysonEmbedded\Merchant( $checkoutUri, $confirmationUri, $notificationUri, $termsUri, $partnerId, $reference );
+		$paysonMerchant  = new PaysonEmbedded\Merchant( $checkoutUri, $confirmationUri, $notificationUri, $termsUri, $partnerId, $reference );
 
 		return $paysonMerchant;
 	}
 
 	public function set_pay_data( $order_id = false ) {
-		include_once( PAYSONCHECKOUT_PATH . '/includes/class-wc-paysoncheckout-process-order-lines.php' );
+		include_once PAYSONCHECKOUT_PATH . '/includes/class-wc-paysoncheckout-process-order-lines.php';
 		$order_lines = new WC_PaysonCheckout_Process_Order_Lines();
 		$payData     = $order_lines->get_order_lines( $order_id );
 		return $payData;
 	}
 
 	public function set_gui() {
-		//require_once PAYSONCHECKOUT_PATH . '/includes/lib/paysonapi.php';
-		$gui = new  PaysonEmbedded\Gui( $this->get_payson_language(), $this->settings['color_scheme'], 'none', $this->get_request_phone(), $this->get_shipping_countries() );
+		// require_once PAYSONCHECKOUT_PATH . '/includes/lib/paysonapi.php';
+		$gui = new PaysonEmbedded\Gui( $this->get_payson_language(), $this->settings['color_scheme'], 'none', $this->get_request_phone(), $this->get_shipping_countries() );
 		return $gui;
 	}
 
@@ -221,10 +252,10 @@ class WC_PaysonCheckout_Setup_Payson_API {
 		$iso_code      = explode( '_', get_locale() );
 		$shop_language = $iso_code[0];
 		switch ( $shop_language ) {
-			case 'sv' :
+			case 'sv':
 				$payson_language = 'sv';
 				break;
-			case 'fi' :
+			case 'fi':
 				$payson_language = 'fi';
 				break;
 			default:
@@ -243,7 +274,7 @@ class WC_PaysonCheckout_Setup_Payson_API {
 	}
 
 	public function set_customer() {
-		//require_once PAYSONCHECKOUT_PATH . '/includes/lib/paysonapi.php';
+		// require_once PAYSONCHECKOUT_PATH . '/includes/lib/paysonapi.php';
 		$email        = '';
 		$postcode     = '';
 		$current_user = wp_get_current_user();
@@ -254,29 +285,29 @@ class WC_PaysonCheckout_Setup_Payson_API {
 		if ( WC()->customer->get_shipping_postcode() ) {
 			$postcode = WC()->customer->get_shipping_postcode();
 		}
-		$customer = new  PaysonEmbedded\Customer( '', '', $email, '', '', '', '', $postcode, '' );
+		$customer = new PaysonEmbedded\Customer( '', '', $email, '', '', '', '', $postcode, '' );
 
 		return $customer;
 	}
 
 	public function get_notification_checkout( $order_id = false ) {
-		//require_once PAYSONCHECKOUT_PATH . '/includes/lib/paysonapi.php';
-		$merchant_id 	= $this->settings['merchant_id'];
-		$api_key     	= $this->settings['api_key'];
-		$environment 	= ( 'yes' == $this->settings['testmode'] ) ? true : false;
-		$callPaysonApi 	= new  PaysonEmbedded\PaysonApi( $merchant_id, $api_key, $environment );
-		$checkout      	= $callPaysonApi->GetCheckout( $order_id );
-		//$checkout 		= $this->verify_customer_data( $checkout );
+		// require_once PAYSONCHECKOUT_PATH . '/includes/lib/paysonapi.php';
+		$merchant_id   = $this->settings['merchant_id'];
+		$api_key       = $this->settings['api_key'];
+		$environment   = ( 'yes' == $this->settings['testmode'] ) ? true : false;
+		$callPaysonApi = new PaysonEmbedded\PaysonApi( $merchant_id, $api_key, $environment );
+		$checkout      = $callPaysonApi->GetCheckout( $order_id );
+		// $checkout         = $this->verify_customer_data( $checkout );
 		WC_Gateway_PaysonCheckout::log( 'Payson GetCheckout request: ' . stripslashes_deep( json_encode( $callPaysonApi ) ) );
 		WC_Gateway_PaysonCheckout::log( 'Payson GetCheckout response (for id ' . $order_id . '): ' . stripslashes_deep( json_encode( $checkout ) ) );
 		return $checkout;
 	}
 
 	public function get_validate_account() {
-		//require_once PAYSONCHECKOUT_PATH . '/includes/lib/paysonapi.php';
-		$merchant_id = $this->settings['merchant_id'];
-		$api_key     = $this->settings['api_key'];
-		$environment = ( 'yes' == $this->settings['testmode'] ) ? true : false;
+		// require_once PAYSONCHECKOUT_PATH . '/includes/lib/paysonapi.php';
+		$merchant_id   = $this->settings['merchant_id'];
+		$api_key       = $this->settings['api_key'];
+		$environment   = ( 'yes' == $this->settings['testmode'] ) ? true : false;
 		$callPaysonApi = new PaysonEmbedded\PaysonApi( $merchant_id, $api_key, $environment );
 		try {
 			$account = $callPaysonApi->Validate();
@@ -291,38 +322,38 @@ class WC_PaysonCheckout_Setup_Payson_API {
 	public function get_shipping_countries() {
 		// Add shipping countries
 		$wc_countries = new WC_Countries();
-		$countries = array_keys( $wc_countries->get_allowed_countries() );
+		$countries    = array_keys( $wc_countries->get_allowed_countries() );
 		return $countries;
 	}
 
 	public function verify_customer_data( $checkout ) {
-		//error_log('$checkout ' . var_export($checkout, true));
-		$billing_first_name     = isset( $checkout->customer->firstName ) ? $checkout->customer->firstName : '.';
-		$billing_last_name      = isset( $checkout->customer->lastName ) ? $checkout->customer->lastName : '.';
-		$billing_address     	= isset( $checkout->customer->street ) ? $checkout->customer->street : '.';
-		$billing_postal_code    = isset( $checkout->customer->postalCode ) ? $checkout->customer->postalCode : '11111';
-		$billing_city     		= isset( $checkout->customer->city ) ? $checkout->customer->city : '.';
-		$billing_country      	= isset( $checkout->customer->countryCode ) ? $checkout->customer->countryCode : '.';
-		$billing_phone      	= isset( $checkout->customer->phone ) ? $checkout->customer->phone : '0700000000';
-		$billing_email      	= isset( $checkout->customer->email ) ? $checkout->customer->email : 'test@test.se';
+		// error_log('$checkout ' . var_export($checkout, true));
+		$billing_first_name  = isset( $checkout->customer->firstName ) ? $checkout->customer->firstName : '.';
+		$billing_last_name   = isset( $checkout->customer->lastName ) ? $checkout->customer->lastName : '.';
+		$billing_address     = isset( $checkout->customer->street ) ? $checkout->customer->street : '.';
+		$billing_postal_code = isset( $checkout->customer->postalCode ) ? $checkout->customer->postalCode : '11111';
+		$billing_city        = isset( $checkout->customer->city ) ? $checkout->customer->city : '.';
+		$billing_country     = isset( $checkout->customer->countryCode ) ? $checkout->customer->countryCode : '.';
+		$billing_phone       = isset( $checkout->customer->phone ) ? $checkout->customer->phone : '0700000000';
+		$billing_email       = isset( $checkout->customer->email ) ? $checkout->customer->email : 'test@test.se';
 
 		$customer_information = array(
-			'billingFirstName'      =>  $billing_first_name,
-			'billingLastName'       =>  $billing_last_name,
-			'billingAddress'        =>  $billing_address,
-			'billingPostalCode'     =>  $billing_postal_code,
-			'billingCity'           =>  $billing_city,
-			'billingCounry'           =>  $billing_country,
-			'shippingFirstName'     =>  $billing_first_name,
-			'shippingLastName'      =>  $billing_last_name,
-			'shippingAddress'       =>  $billing_address,
-			'shippingPostalCode'    =>  $billing_postal_code,
-			'shippingCity'          =>  $billing_city,
-			'shippingCounry'           =>  $billing_country,
-			'phone'                 =>  $billing_phone,
-			'email'                 =>  $billing_email,
+			'billingFirstName'   => $billing_first_name,
+			'billingLastName'    => $billing_last_name,
+			'billingAddress'     => $billing_address,
+			'billingPostalCode'  => $billing_postal_code,
+			'billingCity'        => $billing_city,
+			'billingCounry'      => $billing_country,
+			'shippingFirstName'  => $billing_first_name,
+			'shippingLastName'   => $billing_last_name,
+			'shippingAddress'    => $billing_address,
+			'shippingPostalCode' => $billing_postal_code,
+			'shippingCity'       => $billing_city,
+			'shippingCounry'     => $billing_country,
+			'phone'              => $billing_phone,
+			'email'              => $billing_email,
 		);
-		//error_log('customer_information ' . var_export($customer_information, true));
+		// error_log('customer_information ' . var_export($customer_information, true));
 		return $customer_information;
 	}
 }

--- a/krokedil-wc-compatability.php
+++ b/krokedil-wc-compatability.php
@@ -9,11 +9,16 @@ if ( ! function_exists( 'krokedil_get_wc_version' ) ) {
 	function krokedil_get_wc_version() {
 		return defined( 'WC_VERSION' ) && WC_VERSION ? WC_VERSION : null;
 	}
-	// Check if WooCommerce version is greater or equal to 3.0
+}
+// Check if WooCommerce version is greater or equal to 3.0
+if ( ! function_exists( 'krokedil_wc_gte_3_0' ) ) {
 	function krokedil_wc_gte_3_0() {
 		return krokedil_get_wc_version() && version_compare( krokedil_get_wc_version(), '3.0', '>=' );
 	}
-	// Get the order total
+}
+
+// Get the order total
+if ( ! function_exists( 'krokedil_get_order_total' ) ) {
 	function krokedil_get_order_total( $order ) {
 		if ( krokedil_wc_gte_3_0() ) {
 			return $order->get_total();
@@ -21,7 +26,10 @@ if ( ! function_exists( 'krokedil_get_wc_version' ) ) {
 			return $order->order_total;
 		}
 	}
-	// Get the billing email
+}
+
+if ( ! function_exists( 'krokedil_get_billing_email' ) ) {
+// Get the billing email
 	function krokedil_get_billing_email( $order ) {
 		if ( krokedil_wc_gte_3_0() ) {
 			return $order->get_billing_email();
@@ -29,7 +37,10 @@ if ( ! function_exists( 'krokedil_get_wc_version' ) ) {
 			return $order->billing_email;
 		}
 	}
-	// Get the billing first name
+}
+
+if ( ! function_exists( 'krokedil_get_billing_first_name' ) ) {
+// Get the billing first name
 	function krokedil_get_billing_first_name( $order ) {
 		if ( krokedil_wc_gte_3_0() ) {
 			return $order->get_billing_first_name();
@@ -37,7 +48,10 @@ if ( ! function_exists( 'krokedil_get_wc_version' ) ) {
 			return $order->billing_first_name;
 		}
 	}
-	// Get the billing last name
+}
+
+if ( ! function_exists( 'krokedil_get_billing_last_name' ) ) {
+// Get the billing last name
 	function krokedil_get_billing_last_name( $order ) {
 		if ( krokedil_wc_gte_3_0() ) {
 			return $order->get_billing_last_name();
@@ -45,7 +59,10 @@ if ( ! function_exists( 'krokedil_get_wc_version' ) ) {
 			return $order->billing_last_name;
 		}
 	}
-	// Get the shipping tax
+}
+
+if ( ! function_exists( 'krokedil_get_order_shipping_tax' ) ) {
+// Get the shipping tax
 	function krokedil_get_order_shipping_tax( $order ) {
 		if ( krokedil_wc_gte_3_0() ) {
 			return $order->get_shipping_tax();
@@ -53,7 +70,10 @@ if ( ! function_exists( 'krokedil_get_wc_version' ) ) {
 			return $order->order_shipping_tax;
 		}
 	}
-	// Get the product id
+}
+
+if ( ! function_exists( 'krokedil_get_product_id' ) ) {
+// Get the product id
 	function krokedil_get_product_id( $product ) {
 		if ( krokedil_wc_gte_3_0() ) {
 			return $product->get_id();
@@ -61,7 +81,10 @@ if ( ! function_exists( 'krokedil_get_wc_version' ) ) {
 			return $product->id;
 		}
 	}
-	// Get the order id
+}
+
+if ( ! function_exists( 'krokedil_get_order_id' ) ) {
+// Get the order id
 	function krokedil_get_order_id( $order ) {
 		if ( krokedil_wc_gte_3_0() ) {
 			return $order->get_id();
@@ -69,8 +92,10 @@ if ( ! function_exists( 'krokedil_get_wc_version' ) ) {
 			return $order->id;
 		}
 	}
+}
 
-	// Get item meta
+if ( ! function_exists( 'krokedil_get_item_meta_cart' ) ) {
+// Get item meta
 	function krokedil_get_item_meta_cart( $item, $product ) {
 		if ( krokedil_wc_gte_3_0() ) {
 			$item_meta = '';
@@ -80,7 +105,10 @@ if ( ! function_exists( 'krokedil_get_wc_version' ) ) {
 		}
 		return $item_meta;
 	}
-	function krokedil_get_item_meta_order( $item, $product ) {
+}
+
+if ( ! function_exists( 'krokedil_get_item_meta_order' ) ) {
+function krokedil_get_item_meta_order( $item, $product ) {
 		if ( krokedil_wc_gte_3_0() ) {
 			$item_meta = strip_tags( wc_display_item_meta( $item, array(
 				'before'    => '',
@@ -98,7 +126,10 @@ if ( ! function_exists( 'krokedil_get_wc_version' ) ) {
 			return $item_meta;
 		}
 	}
-	function krokedil_get_payment_method( $order ) {
+}
+
+if ( ! function_exists( 'krokedil_get_payment_method' ) ) {
+function krokedil_get_payment_method( $order ) {
 		if ( krokedil_wc_gte_3_0() ) {
 			return $order->get_payment_method();
 		} else {

--- a/paysoncheckout-for-woocommerce.php
+++ b/paysoncheckout-for-woocommerce.php
@@ -3,13 +3,17 @@
  * Plugin Name:     PaysonCheckout 2.0 for WooCommerce
  * Plugin URI:      http://krokedil.com/
  * Description:     Provides a PaysonCheckout 2.0 payment gateway for WooCommerce.
- * Version:         1.3.1
+ * Version:         1.4.0
  * Author:          Krokedil
  * Author URI:      http://krokedil.com/
  * Developer:       Krokedil
  * Developer URI:   http://krokedil.com/
  * Text Domain:     woocommerce-gateway-paysoncheckout
  * Domain Path:     /languages
+ * 
+ * WC requires at least: 3.0
+ * WC tested up to: 3.4.6
+ * 
  * Copyright:       © 2016-2018 Krokedil.
  * License:         GNU General Public License v3.0
  * License URI:     http://www.gnu.org/licenses/gpl-3.0.html
@@ -25,7 +29,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 load_plugin_textdomain( 'woocommerce-gateway-paysoncheckout', false, dirname( plugin_basename( __FILE__ ) ) . '/languages/' );
 
 // Define plugin constants.
-define( 'PAYSONCHECKOUT_VERSION', '1.3.1' );
+define( 'PAYSONCHECKOUT_VERSION', '1.4.0' );
 define( 'PAYSONCHECKOUT_URL', untrailingslashit( plugins_url( '/', __FILE__ ) ) );
 define( 'PAYSONCHECKOUT_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 

--- a/paysoncheckout-for-woocommerce.php
+++ b/paysoncheckout-for-woocommerce.php
@@ -43,6 +43,7 @@ include_once( 'includes/class-wc-paysoncheckout-capture.php' );
 include_once( 'includes/class-wc-paysoncheckout-cancel-reservation.php' );
 include_once( 'includes/class-wc-paysoncheckout-admin-notices.php' );
 include_once( 'krokedil-wc-compatability.php' );
+include_once( 'includes/class-wc-paysoncheckout-gdpr.php' );
 
 include_once( 'includes/class-wc-paysoncheckout-templates.php' );
 include_once( 'includes/class-wc-paysoncheckout-functions.php' );


### PR DESCRIPTION
* Feature	- Added support for wp_add_privacy_policy_content (for GDPR compliance). More info: https://core.trac.wordpress.org/attachment/ticket/43473/PRIVACY-POLICY-CONTENT-HOOK.md.
* Tweak - Improved error messaging in Payson account check request.
* Fix - Updated compatability functions to prevent error.
* Tweak - Added filters payson_pay_data, payson_gui & payson_customer to allow merchants to modify order data sent to Payson.
* Tweak - Added company name to WooCommerce order if purchase is a B2B order.
* Fix - Changed how JS eventlistener PaysonEmbeddedAddressChanged was implemented. Some websites was not able to retrieve customer address data.
* Fix	- Submission failure process bug fix. Order is now created in Woo and customer redirected to thankyou page even if original checkout form submission fails.