### PR TITLE
Add plugin setting to enable/disable order validation

### DIFF
--- a/classes/class-paysoncheckout-for-woocommerce-gateway.php
+++ b/classes/class-paysoncheckout-for-woocommerce-gateway.php
@@ -39,6 +39,7 @@ class PaysonCheckout_For_WooCommerce_Gateway extends WC_Payment_Gateway {
 		$this->request_phone    = $this->get_option( 'request_phone' );
 		$this->debug            = $this->get_option( 'debug' );
 		$this->order_management = $this->get_option( 'order_management' );
+		$this->order_validation = $this->get_option( 'order_validation' );
 
 		// Supports.
 		$this->supports = array( 'products', 'refunds' );

--- a/classes/requests/helpers/class-paysoncheckout-for-woocommerce-helper-merchant.php
+++ b/classes/requests/helpers/class-paysoncheckout-for-woocommerce-helper-merchant.php
@@ -20,6 +20,8 @@ class PaysonCheckout_For_WooCommerce_Helper_Merchant {
 	 * @return array
 	 */
 	public function get_merchant_urls() {
+		$payson_settings = get_option( 'woocommerce_paysoncheckout_settings' );
+
 		// Maybe set the confirmation URI to include payment id.
 		$confirmation_uri_args = array( 'pco_confirm' => '1' );
 		if ( WC()->session->get( 'payson_payment_id' ) ) {
@@ -30,12 +32,15 @@ class PaysonCheckout_For_WooCommerce_Helper_Merchant {
 			wc_get_checkout_url()
 		);
 
-		// Set validation URI query args.
-		$validation_uri_args = array( 'pco_session_id' => PCO_WC()->session->get_session_id() );
-		$validation_uri      = add_query_arg(
-			$validation_uri_args,
-			get_home_url() . '/wc-api/PCO_WC_Validation'
-		);
+		$validation_uri = null;
+		if ( 'yes' === $payson_settings['order_validation'] ) {
+			// Set validation URI query args.
+			$validation_uri_args = array( 'pco_session_id' => PCO_WC()->session->get_session_id() );
+			$validation_uri      = add_query_arg(
+				$validation_uri_args,
+				get_home_url() . '/wc-api/PCO_WC_Validation'
+			);
+		}
 
 		return array(
 			'checkoutUri'     => wc_get_checkout_url(), // String.

--- a/includes/paysoncheckout-for-woocommerce-form-fields.php
+++ b/includes/paysoncheckout-for-woocommerce-form-fields.php
@@ -78,6 +78,12 @@ $settings = array(
 		'label'   => __( 'Check this box to require the customer to fill in his phone number.', 'woocommerce-gateway-paysoncheckout' ),
 		'default' => 'no',
 	),
+	'order_validation'              => array(
+		'title'   => __( 'Enable order validation', 'woocommerce-gateway-paysoncheckout' ),
+		'type'    => 'checkbox',
+		'label'   => __( 'Check this box to perform order validation before payment.', 'woocommerce-gateway-paysoncheckout' ),
+		'default' => 'no',
+	),
 	'debug'                      => array(
 		'title'       => __( 'Debug Log', 'woocommerce-gateway-paysoncheckout' ),
 		'type'        => 'checkbox',


### PR DESCRIPTION
To use the plugin in a test environment it should be a way to disable order validation.