### PR TITLE
V2.1.1

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -2,9 +2,9 @@
 Contributors: krokedil, niklashogefjord
 Tags: ecommerce, e-commerce, woocommerce, payson, paysoncheckout2.0
 Requires at least: 4.5
-Tested up to: 5.2.1
+Tested up to: 5.2.2
 WC requires at least: 3.0
-WC tested up to: 3.6.4
+WC tested up to: 3.6.5
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 Stable tag: trunk
@@ -36,6 +36,11 @@ More information on how to get started can be found in the [plugin documentation
 
 
 == CHANGELOG ==
+
+= 2019.08.09	- version 2.1.1 =
+* Fix			- Updating nonce correctly on update_checkout. This could cause issues finalizing order if logging in on checkout page.
+* Fix			- Added checks to prevent JS error with some themes in checkout page.
+* Fix			- Fix for order going through even if login in required and user isn't logged in.
 
 = 2019.05.28	- version 2.1.0 =
 * Feature	    - Added support for recurring orders through WooCommerce Subscriptions ( https://woocommerce.com/products/woocommerce-subscriptions/ ).

--- a/README.txt
+++ b/README.txt
@@ -37,6 +37,12 @@ More information on how to get started can be found in the [plugin documentation
 
 == CHANGELOG ==
 
+= 2019.05.28	- version 2.1.0 =
+* Feature	    - Added support for recurring orders through WooCommerce Subscriptions ( https://woocommerce.com/products/woocommerce-subscriptions/ ).
+* Enhancement   - Better handling of payment id transfer between frontend and server to server calls.
+* Fix           - Fixed fee totals calculations. Caused missmatches between Payson and WooCommerce.
+* Fix			- Set customer country properly on server to server callbacks. WooCommerce 3.6 compatible.
+
 = 2019.04.18	- version 2.0.3 =
 * Enhancement	- Added swedish translation of plugin.
 * Fix			- Fixed an issue getting a fee name.

--- a/assets/js/pco_checkout.js
+++ b/assets/js/pco_checkout.js
@@ -300,10 +300,12 @@ jQuery(function($) {
 			let fieldData = JSON.parse( sessionStorage.getItem( 'PCOFieldData' ) );
 			// Check if all data is set for required fields.
 			let allValid = true;
-			for( i = 0; i < requiredFields.length; i++ ) {
-				fieldName = requiredFields[i];
-				if ( '' === fieldData[fieldName] ) {
-					allValid = false;
+			if ( requiredFields !== null ) {
+				for( i = 0; i < requiredFields.length; i++ ) {
+					fieldName = requiredFields[i];
+					if ( '' === fieldData[fieldName] ) {
+						allValid = false;
+					}
 				}
 			}
 			pco_wc.maybeFreezeIframe( allValid );
@@ -344,25 +346,27 @@ jQuery(function($) {
 		 */
 		setFormFieldValues: function() {
 			let form_data = JSON.parse( sessionStorage.getItem( 'PCOFieldData' ) );
-			$.each( form_data, function( name, value ) {
-				let field = $('*[name="' + name + '"]');
-				let saved_value = value;
-				// Check if field is a checkbox
-				if( field.is(':checkbox') ) {
-					if( saved_value !== '' ) {
-						field.prop('checked', true);
-					}
-				} else if( field.is(':radio') ) {
-					for ( x = 0; x < field.length; x++ ) {
-						if( field[x].value === value ) {
-							$(field[x]).prop('checked', true);
+			if( form_data !== null ) {
+				$.each( form_data, function( name, value ) {
+					let field = $('*[name="' + name + '"]');
+					let saved_value = value;
+					// Check if field is a checkbox
+					if( field.is(':checkbox') ) {
+						if( saved_value !== '' ) {
+							field.prop('checked', true);
 						}
+					} else if( field.is(':radio') ) {
+						for ( x = 0; x < field.length; x++ ) {
+							if( field[x].value === value ) {
+								$(field[x]).prop('checked', true);
+							}
+						}
+					} else {
+						field.val( saved_value );
 					}
-				} else {
-					field.val( saved_value );
-				}
 
-			});
+				});
+			}
 		},
 
 		/**

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,11 @@
 *** PaysonCheckout 2.0 Changelog ***
 
+2019.05.28	    - version 2.1.0
+* Feature	    - Added support for recurring orders through WooCommerce Subscriptions ( https://woocommerce.com/products/woocommerce-subscriptions/ ).
+* Enhancement   - Better handling of payment id transfer between frontend and server to server calls.
+* Fix           - Fixed fee totals calculations. Caused missmatches between Payson and WooCommerce.
+* Fix			- Set customer country properly on server to server callbacks. WooCommerce 3.6 compatible.
+
 2019.04.18		- version 2.0.3
 * Enhancement	- Added swedish translation of plugin.
 * Fix			- Fixed an issue getting a fee name.

--- a/classes/class-paysoncheckout-for-woocommerce-callbacks.php
+++ b/classes/class-paysoncheckout-for-woocommerce-callbacks.php
@@ -58,7 +58,6 @@ class PaysonCheckout_For_WooCommerce_Callbacks {
 		}
 
 		$this->payson_order = pco_wc_get_order( $payment_id );
-
 		// Check if we have a session id.
 		$this->check_session_id();
 
@@ -77,6 +76,11 @@ class PaysonCheckout_For_WooCommerce_Callbacks {
 
 		// Check that all items are still in stock.
 		$this->check_all_in_stock();
+
+		// Subscription specific controlls.
+		if ( $subscription ) {
+			$this->check_if_user_exists_and_logged_in();
+		}
 
 		// Check if order is still valid.
 		if ( $this->order_is_valid ) {
@@ -188,6 +192,24 @@ class PaysonCheckout_For_WooCommerce_Callbacks {
 		if ( true !== $stock_check ) {
 			$this->order_is_valid                      = false;
 			$this->validation_messages['amount_error'] = __( 'Not all items are in stock.', 'woocommerce-gateway-payson' );
+		}
+	}
+
+	/**
+	 * Checks if the email exists as a user and if they are logged in.
+	 *
+	 * @return void
+	 */
+	public function check_if_user_exists_and_logged_in() {
+		// Check if the email exists as a user
+		$user = email_exists( $this->payson_order['customer']['email'] );
+
+		// If not false, user exists. Check if the session id matches the User id.
+		if ( false !== $user ) {
+			if ( $user != $_GET['pco_session_id'] ) {
+				$this->order_is_valid                    = false;
+				$this->validation_messages['user_login'] = __( 'An account already exists with this email. Please login to complete the purchase.', 'woocommerce-gateway-payson' );
+			}
 		}
 	}
 }

--- a/classes/class-paysoncheckout-for-woocommerce-callbacks.php
+++ b/classes/class-paysoncheckout-for-woocommerce-callbacks.php
@@ -201,7 +201,7 @@ class PaysonCheckout_For_WooCommerce_Callbacks {
 	 * @return void
 	 */
 	public function check_if_user_exists_and_logged_in() {
-		// Check if the email exists as a user
+		// Check if the email exists as a user.
 		$user = email_exists( $this->payson_order['customer']['email'] );
 
 		// If not false, user exists. Check if the session id matches the User id.

--- a/classes/class-paysoncheckout-for-woocommerce-templates.php
+++ b/classes/class-paysoncheckout-for-woocommerce-templates.php
@@ -27,7 +27,6 @@ class PaysonCheckout_For_WooCommerce_Templates {
 	 *
 	 * @param string $template      Template.
 	 * @param string $template_name Template name.
-	 * @param string $template_path Template path.
 	 * @return string
 	 */
 	public function override_template( $template, $template_name ) {
@@ -88,10 +87,18 @@ class PaysonCheckout_For_WooCommerce_Templates {
 		<div aria-hidden="true" id="pco-wc-form" style="position:absolute; top:0; left:-99999px;">
 			<?php do_action( 'woocommerce_checkout_billing' ); ?>
 			<?php do_action( 'woocommerce_checkout_shipping' ); ?>
-			<div id="pco-nonce-wrapper">
-				<?php wp_nonce_field( 'woocommerce-process_checkout', 'woocommerce-process-checkout-nonce' ); ?>
-			</div>
-			<input id="payment_method_paysoncheckout" type="radio" class="input-radio" name="payment_method" value="paysoncheckout" checked="checked" />
+			<?php
+			if ( isset( $_GET['pco_confirm'] ) ) {
+				// On confirmation page - render woocommerce_checkout_payment() to get the woocommerce-process-checkout-nonce correct.
+				woocommerce_checkout_payment();
+			} else {
+				// On regular PCO checkout page - use our own woocommerce-process-checkout-nonce (so we don't render the checkout form submit button).
+				?>
+				<div id="pco-nonce-wrapper">
+					<?php wp_nonce_field( 'woocommerce-process_checkout', 'woocommerce-process-checkout-nonce' ); ?>
+				</div>
+				<input id="payment_method_paysoncheckout" type="radio" class="input-radio" name="payment_method" value="paysoncheckout" checked="checked" />
+			<?php }; ?>
 		</div>
 		<?php
 	}

--- a/paysoncheckout-for-woocommerce.php
+++ b/paysoncheckout-for-woocommerce.php
@@ -3,7 +3,7 @@
  * Plugin Name:     PaysonCheckout 2.0 for WooCommerce
  * Plugin URI:      http://krokedil.com/
  * Description:     Provides a PaysonCheckout 2.0 payment gateway for WooCommerce.
- * Version:         2.0.3
+ * Version:         2.1.0
  * Author:          Krokedil
  * Author URI:      http://krokedil.com/
  * Developer:       Krokedil
@@ -26,7 +26,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // Define plugin constants.
-define( 'PAYSONCHECKOUT_VERSION', '2.0.3' );
+define( 'PAYSONCHECKOUT_VERSION', '2.1.0' );
 define( 'PAYSONCHECKOUT_URL', untrailingslashit( plugins_url( '/', __FILE__ ) ) );
 define( 'PAYSONCHECKOUT_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'PAYSONCHECKOUT_LIVE_ENV', 'https://api.payson.se/2.0/' );

--- a/paysoncheckout-for-woocommerce.php
+++ b/paysoncheckout-for-woocommerce.php
@@ -3,7 +3,7 @@
  * Plugin Name:     PaysonCheckout 2.0 for WooCommerce
  * Plugin URI:      http://krokedil.com/
  * Description:     Provides a PaysonCheckout 2.0 payment gateway for WooCommerce.
- * Version:         2.1.0
+ * Version:         2.1.1
  * Author:          Krokedil
  * Author URI:      http://krokedil.com/
  * Developer:       Krokedil
@@ -12,7 +12,7 @@
  * Domain Path:     /languages
  *
  * WC requires at least: 3.0
- * WC tested up to: 3.6.4
+ * WC tested up to: 3.6.5
  *
  * Copyright:       © 2016-2019 Krokedil.
  * License:         GNU General Public License v3.0
@@ -26,7 +26,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // Define plugin constants.
-define( 'PAYSONCHECKOUT_VERSION', '2.1.0' );
+define( 'PAYSONCHECKOUT_VERSION', '2.1.1' );
 define( 'PAYSONCHECKOUT_URL', untrailingslashit( plugins_url( '/', __FILE__ ) ) );
 define( 'PAYSONCHECKOUT_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'PAYSONCHECKOUT_LIVE_ENV', 'https://api.payson.se/2.0/' );


### PR DESCRIPTION
* Fix - Updating nonce correctly on update_checkout. This could cause issues finalizing order if logging in on checkout page.
* Fix	- Added checks to prevent JS error with some themes in checkout page.
* Fix	- Fix for order going through even if login in required and user isn't logged in.