### PR TITLE
Fix Payson not available on subscriptions payment change

### DIFF
--- a/classes/class-paysoncheckout-for-woocommerce-gateway.php
+++ b/classes/class-paysoncheckout-for-woocommerce-gateway.php
@@ -49,7 +49,7 @@ class PaysonCheckout_For_WooCommerce_Gateway extends WC_Payment_Gateway {
 			'subscription_reactivation',
 			'subscription_amount_changes',
 			'subscription_date_changes',
-			'subscription_payment_method_change',
+			'subscription_payment_method_change_customer',
 			'subscription_payment_method_change_admin',
 			'multiple_subscriptions',
 		);


### PR DESCRIPTION
Payson was not showing up due to a typo.