### PR TITLE
Check if the Payson settings has been saved yet

### DIFF
--- a/classes/requests/class-paysoncheckout-for-woocommerce-request.php
+++ b/classes/requests/class-paysoncheckout-for-woocommerce-request.php
@@ -42,14 +42,14 @@ class PaysonCheckout_For_WooCommerce_Request {
 	 * @return void
 	 */
 	public function set_enviroment() {
-		$live_enviroment = 'https://api.payson.se/2.0/';
-		$test_enviroment = 'https://test-api.payson.se/2.0/';
 		$payson_settings = get_option( 'woocommerce_paysoncheckout_settings' );
 
-		if ( 'no' === $payson_settings['testmode'] ) {
-			$this->enviroment = 'https://api.payson.se/2.0/';
-		} else {
-			$this->enviroment = 'https://test-api.payson.se/2.0/';
+		if ( ! empty( $payson_settings ) ) {
+			if ( 'no' === $payson_settings['testmode'] ) {
+				$this->enviroment = 'https://api.payson.se/2.0/';
+			} else {
+				$this->enviroment = 'https://test-api.payson.se/2.0/';
+			}
 		}
 	}
 


### PR DESCRIPTION
This tends to happen when the plugin is installed for the first time (and the Payson settings has not yet been saved to the database yet).

```
Notice: Trying to access array offset on value of type bool in paysoncheckout-for-woocommerce\classes\requests\class-paysoncheckout-for-woocommerce-request.php on line 49
```