### PR TITLE
Fix WP_Error accessed as an array

### DIFF
--- a/classes/class-paysoncheckout-for-woocommerce-logger.php
+++ b/classes/class-paysoncheckout-for-woocommerce-logger.php
@@ -96,20 +96,6 @@ class PaysonCheckout_For_WooCommerce_Logger {
 	}
 
 	/**
-	 * Formats the log data to be logged.
-	 *
-	 * @param string $payment_id The Payson Payment ID.
-	 * @param string $method The method.
-	 * @param string $title The title for the log.
-	 * @param array  $request_args The request args.
-	 * @param array  $response The response.
-	 * @param string $code The status code.
-	 * @return array
-	 */
-	public static function format_error( $payment_id, $method, $title, $request_args, $response, $code ) {
-
-	}
-	/**
 	 * Gets the stack for the request.
 	 *
 	 * @return array

--- a/classes/class-paysoncheckout-for-woocommerce-logger.php
+++ b/classes/class-paysoncheckout-for-woocommerce-logger.php
@@ -96,6 +96,20 @@ class PaysonCheckout_For_WooCommerce_Logger {
 	}
 
 	/**
+	 * Formats the log data to be logged.
+	 *
+	 * @param string $payment_id The Payson Payment ID.
+	 * @param string $method The method.
+	 * @param string $title The title for the log.
+	 * @param array  $request_args The request args.
+	 * @param array  $response The response.
+	 * @param string $code The status code.
+	 * @return array
+	 */
+	public static function format_error( $payment_id, $method, $title, $request_args, $response, $code ) {
+
+	}
+	/**
 	 * Gets the stack for the request.
 	 *
 	 * @return array

--- a/classes/requests/checkout/class-paysoncheckout-for-woocommerce-update-reference.php
+++ b/classes/requests/checkout/class-paysoncheckout-for-woocommerce-update-reference.php
@@ -37,14 +37,14 @@ class PaysonCheckout_For_WooCommerce_Update_Reference extends PaysonCheckout_For
 			return $payson_data;
 		}
 
-		$response          = wp_remote_request( $request_url, $request_args );
-		$code              = wp_remote_retrieve_response_code( $response );
-		$formated_response = $this->process_response( $response, $request_args, $request_url );
+		$response           = wp_remote_request( $request_url, $request_args );
+		$code               = wp_remote_retrieve_response_code( $response );
+		$formatted_response = $this->process_response( $response, $request_args, $request_url );
 
 		// Log the request.
 		$log = PaysonCheckout_For_WooCommerce_Logger::format_log( $payment_id, 'PUT', 'Payson update reference request.', $request_args, json_decode( wp_remote_retrieve_body( $response ), true ), $code );
 		PaysonCheckout_For_WooCommerce_Logger::log( $log );
-		return $formated_response;
+		return $formatted_response;
 	}
 
 	/**

--- a/classes/requests/checkout/class-paysoncheckout-for-woocommerce-update-reference.php
+++ b/classes/requests/checkout/class-paysoncheckout-for-woocommerce-update-reference.php
@@ -21,7 +21,7 @@ class PaysonCheckout_For_WooCommerce_Update_Reference extends PaysonCheckout_For
 	 * @return array|WP_Error|false If the request could not be issued, FALSE is returned. Otherwise, WP_Error or an array.
 	 */
 	public function request( $order_id = null, $payson_data = null ) {
-		$payment_id   = WC()->session->get( 'payson_payment_id', null ) ?? WC()->session->get( 'payson_payment_id' ) ?? $payson_data['id'] ?? null;
+		$payment_id   = WC()->session?->get( 'payson_payment_id' ) ?? $payson_data['id'] ?? null;
 		$request_url  = $this->enviroment . 'Checkouts/' . $payment_id;
 		$request_args = apply_filters( 'pco_update_order_args', $this->get_request_args( $order_id, $payson_data ) );
 		if ( null !== WC()->session ) {


### PR DESCRIPTION
Additionally, no request will be issued to Payson since without a valid payment ID the transaction cannot be identified.