### PR TITLE
Add setting for checkout layout

### DIFF
--- a/assets/css/pco_style.css
+++ b/assets/css/pco_style.css
@@ -1,3 +1,4 @@
+/* @todo - remove pco-modal & pco-modal-content? */
 .pco-modal {
     position: fixed; /* Stay in place */
     z-index: 1000; /* Sit on top */
@@ -17,4 +18,36 @@
     border: 1px solid #888;
     max-width: 600px; /* Could be more or less, depending on screen size */
     text-align: center;
+}
+
+/* Checkout design */
+.payson-checkout-selected textarea[name="order_comments"] { 
+    resize: vertical; 
+}
+
+/* Desktop view / multi columns */
+@media only screen and (min-width : 769px) {
+
+    .payson-checkout-two-column-right #pco-wrapper {
+        display: grid;
+        grid-template-columns: 4fr 6fr;	
+        grid-column-gap: 70px;
+    }
+
+    .payson-checkout-two-column-left #pco-wrapper,
+    .payson-checkout-two-column-left-sf #pco-wrapper {
+        display: grid;
+        grid-template-columns: 6fr 4fr;	
+        grid-column-gap: 70px;
+    }
+
+    .payson-checkout-two-column-left #pco-order-review,
+    .payson-checkout-two-column-left-sf #pco-order-review {
+        order: 2;
+    }
+
+    .payson-checkout-two-column-left #pco-iframe,
+    .payson-checkout-two-column-left-sf #pco-iframe {
+        order: 1;
+    }
 }

--- a/includes/paysoncheckout-for-woocommerce-form-fields.php
+++ b/includes/paysoncheckout-for-woocommerce-form-fields.php
@@ -74,6 +74,18 @@ $settings = array(
 			'b2b' => 'B2B',
 		),
 	),
+	'checkout_layout'              => array(
+		'title'       => __( 'Checkout layout', 'woocommerce-gateway-paysoncheckout' ),
+		'type'        => 'select',
+		'options'     => array(
+			'one_column_checkout' => __( 'One column checkout', 'dintero-checkout-for-woocommerce' ),
+			'two_column_right'    => __( 'Two column checkout (Payson Checkout in right column)', 'woocommerce-gateway-paysoncheckout' ),
+			'two_column_left'     => __( 'Two column checkout (Payson Checkout in left column)', 'woocommerce-gateway-paysoncheckout' ),
+		),
+		'description' => __( 'Select the Checkout layout.', 'woocommerce-gateway-paysoncheckout' ),
+		'default'     => 'one_column_checkout',
+		'desc_tip'    => false,
+	),
 	'color_scheme'                 => array(
 		'title'       => __( 'Color Scheme', 'woocommerce-gateway-paysoncheckout' ),
 		'type'        => 'select',


### PR DESCRIPTION
* Adds support for multiple checkout layouts via new setting "Checkout layout". 
* Also moves pco_wc_show_another_gateway_button from pco_wc_before_snippet hook to pco_wc_after_order_review.