### PR TITLE
Develop refund subscription

### DIFF
--- a/classes/class-paysoncheckout-for-woocommerce-order-management.php
+++ b/classes/class-paysoncheckout-for-woocommerce-order-management.php
@@ -204,93 +204,76 @@ class PaysonCheckout_For_WooCommerce_Order_Management {
 	 * @return boolean Did the refund go through okay?
 	 */
 	public function refund_payment( $order_id ) {
-				$query_args = array(
-					'fields'         => 'id=>parent',
-					'post_type'      => 'shop_order_refund',
-					'post_status'    => 'any',
-					'posts_per_page' => -1,
-				);
+		$order        = wc_get_order( $order_id );
+		$payment_id   = get_post_meta( $order_id, '_payson_checkout_id', true );
+		$subscription = $this->check_if_subscription( $order );
 
-				$refunds = get_posts( $query_args );
+		// Get the Payson order.
+		$payson_order_tmp = ( $subscription ) ? PCO_WC()->get_recurring_payment->request( $payment_id ) : PCO_WC()->get_order->request( $payment_id );
+		$refund_order     = $order->get_refunds()[0];
 
-				$refund_order_id = array_search( $order_id, $refunds );
-				if ( is_array( $refund_order_id ) ) {
-					foreach ( $refund_order_id as $key => $value ) {
-						$refund_order_id = $value;
-						break;
-					}
+		foreach ( $payson_order_tmp['order']['items'] as $key => $payson_item ) {
+			$continue = false;
+			foreach ( $refund_order->get_items() as $refund_item ) {
+				$product = $refund_item->get_product();
+				if ( $product->get_sku() === $payson_item['reference'] || (string) $product->get_id() === $payson_item['reference'] ) {
+					$payson_item['creditedAmount']              = $payson_item['creditedAmount'] + abs( $refund_item->get_total() + $refund_item->get_total_tax() );
+					$payson_order_tmp['order']['items'][ $key ] = $payson_item;
+					$continue                                   = true;
+					break;
 				}
+			}
 
-				$order        = wc_get_order( $order_id );
-				$payment_id   = get_post_meta( $order_id, '_payson_checkout_id', true );
-				$subscription = $this->check_if_subscription( $order );
+			if ( $continue ) {
+				continue;
+			}
 
-				// Get the Payson order.
-				$payson_order_tmp = ( $subscription ) ? PCO_WC()->get_recurring_payment->request( $payment_id ) : PCO_WC()->get_order->request( $payment_id );
-				$refund_order     = wc_get_order( $refund_order_id );
+			$refund_shipping = $refund_order->get_shipping_method();
 
-				foreach ( $payson_order_tmp['order']['items'] as $key => $payson_item ) {
-					$continue = false;
-					foreach ( $refund_order->get_items() as $refund_item ) {
-						$product = $refund_item->get_product();
-						if ( $product->get_sku() === $payson_item['reference'] || (string) $product->get_id() === $payson_item['reference'] ) {
-							$payson_item['creditedAmount']              = $payson_item['creditedAmount'] + abs( $refund_item->get_total() + $refund_item->get_total_tax() );
-							$payson_order_tmp['order']['items'][ $key ] = $payson_item;
-							$continue                                   = true;
-							break;
-						}
-					}
+			if ( $payson_item['name'] === $refund_shipping ) {
+				$payson_item['creditedAmount']              = $payson_item['creditedAmount'] + abs( $refund_order->get_shipping_total() + $refund_order->get_shipping_tax() );
+				$payson_order_tmp['order']['items'][ $key ] = $payson_item;
+				$continue                                   = true;
+				break;
+			}
 
-					if ( $continue ) {
-						continue;
-					}
+			if ( $continue ) {
+				continue;
+			}
 
-					$refund_shipping = $refund_order->get_shipping_method();
-
-					if ( $payson_item['name'] === $refund_shipping ) {
-						$payson_item['creditedAmount']              = $payson_item['creditedAmount'] + abs( $refund_order->get_shipping_total() + $refund_order->get_shipping_tax() );
-						$payson_order_tmp['order']['items'][ $key ] = $payson_item;
-						$continue                                   = true;
-						break;
-					}
-
-					if ( $continue ) {
-						continue;
-					}
-
-					foreach ( $refund_order->get_fees() as $refund_fee ) {
-						if ( $payson_item['name'] === $refund_fee->get_name() ) {
-							$payson_item['creditedAmount']              = $payson_item['creditedAmount'] + abs( $refund_fee->get_total() + $refund_fee->get_total_tax() );
-							$payson_order_tmp['order']['items'][ $key ] = $payson_item;
-							$continue                                   = true;
-							break;
-						}
-					}
+			foreach ( $refund_order->get_fees() as $refund_fee ) {
+				if ( $payson_item['name'] === $refund_fee->get_name() ) {
+					$payson_item['creditedAmount']              = $payson_item['creditedAmount'] + abs( $refund_fee->get_total() + $refund_fee->get_total_tax() );
+					$payson_order_tmp['order']['items'][ $key ] = $payson_item;
+					$continue                                   = true;
+					break;
 				}
+			}
+		}
 
-				$payson_order_tmp['order']['totalCreditedAmount'] = $payson_order_tmp['order']['totalCreditedAmount'] + abs( $refund_order->get_total() );
-				$payson_order                                     = PCO_WC()->refund_order->request( $order_id, $payson_order_tmp, $payment_id, $subscription );
+		$payson_order_tmp['order']['totalCreditedAmount'] = $payson_order_tmp['order']['totalCreditedAmount'] + abs( $refund_order->get_total() );
+		$payson_order                                     = PCO_WC()->refund_order->request( $order_id, $payson_order_tmp, $payment_id, $subscription );
 
-				if ( is_wp_error( $payson_order ) ) {
-					// If error, save error message and return false.
-					$code          = $payson_order->get_error_code();
-					$message       = $payson_order->get_error_message();
-					$text          = __( 'Payson API Error on Payson refund: ', 'payson-checkout-for-woocommerce' ) . '%s %s';
-					$formated_text = sprintf( $text, $code, $message );
-					$order->add_order_note( $formated_text );
-					return false;
-				}
+		if ( is_wp_error( $payson_order ) ) {
+			// If error, save error message and return false.
+			$code          = $payson_order->get_error_code();
+			$message       = $payson_order->get_error_message();
+			$text          = __( 'Payson API Error on Payson refund: ', 'payson-checkout-for-woocommerce' ) . '%s %s';
+			$formated_text = sprintf( $text, $code, $message );
+			$order->add_order_note( $formated_text );
+			return false;
+		}
 
 				// If Payson do not accept the refund, the totalCreditedAmount we sent, and the one they respond with, will not match.
-				if ( $payson_order_tmp['order']['totalCreditedAmount'] !== $payson_order['order']['totalCreditedAmount'] ) {
+		if ( $payson_order_tmp['order']['totalCreditedAmount'] !== $payson_order['order']['totalCreditedAmount'] ) {
 
-					$order->add_order_note( __( 'Credited amount mismatch', 'payson-checkout-for-woocommerce' ) );
-					return false;
+			$order->add_order_note( __( 'Credited amount mismatch', 'payson-checkout-for-woocommerce' ) );
+			return false;
 
-				}
+		}
 
-				$order->add_order_note( __( 'PaysonCheckout reservation was successfully refunded for ', 'woocommerce-gateway-paysoncheckout' ) . wc_price( abs( $refund_order->get_total() ) ) );
-				return true;
+		$order->add_order_note( __( 'PaysonCheckout reservation was successfully refunded for ', 'woocommerce-gateway-paysoncheckout' ) . wc_price( abs( $refund_order->get_total() ) ) );
+		return true;
 	}
 
 	/**

--- a/classes/requests/helpers/class-paysoncheckout-for-woocommerce-helper-cart.php
+++ b/classes/requests/helpers/class-paysoncheckout-for-woocommerce-helper-cart.php
@@ -107,7 +107,7 @@ class PaysonCheckout_For_WooCommerce_Helper_Cart {
 	}
 
 	/**
-	 * Undocumented function
+	 * Get the product SKU (defaults to ID).
 	 *
 	 * @param object $product The WooCommerce Product.
 	 * @return string

--- a/classes/requests/helpers/class-paysoncheckout-for-woocommerce-helper-order.php
+++ b/classes/requests/helpers/class-paysoncheckout-for-woocommerce-helper-order.php
@@ -57,6 +57,7 @@ class PaysonCheckout_For_WooCommerce_Helper_Order {
 			'unitPrice' => $this->get_product_unit_price( $order_item ), // Float.
 			'quantity'  => $order_item->get_quantity(), // Float.
 			'taxRate'   => $this->get_product_tax_rate( $order, $order_item ), // Float.
+			'reference' => $this->get_product_sku( $order_item ), // String.
 		);
 	}
 
@@ -144,5 +145,22 @@ class PaysonCheckout_For_WooCommerce_Helper_Order {
 				'reference' => __( 'Shipping', 'payson-checkout-for-woocommerce' ), // String.
 			);
 		}
+	}
+
+	/**
+	 * Get the product SKU (defaults to ID).
+	 *
+	 * @param WC_Order_Item_Product $order_item The WooCommerce Product.
+	 * @return string
+	 */
+	public function get_product_sku( $order_item ) {
+		$product = $order_item->get_product();
+		if ( $product->get_sku() ) {
+			$item_reference = $product->get_sku();
+		} else {
+			$item_reference = $product->get_id();
+		}
+
+		return $item_reference;
 	}
 }


### PR DESCRIPTION
- Modified the way we identify and retrieve the refunded order. Instead of querying all posts, use `get_refunds` instead.
- Added the missing product reference to the order line (required to identify the product/subscription)