### PR TITLE
Remove support for changing subscription payment method

### DIFF
--- a/classes/class-paysoncheckout-for-woocommerce-gateway.php
+++ b/classes/class-paysoncheckout-for-woocommerce-gateway.php
@@ -49,8 +49,6 @@ class PaysonCheckout_For_WooCommerce_Gateway extends WC_Payment_Gateway {
 			'subscription_reactivation',
 			'subscription_amount_changes',
 			'subscription_date_changes',
-			'subscription_payment_method_change_customer',
-			'subscription_payment_method_change_admin',
 			'multiple_subscriptions',
 		);
 


### PR DESCRIPTION
Payson do not support changing subscription payment method through their API. Instead the customer can change the payment method through the merchant portal.