### PR TITLE
Version 3.6.1

### DIFF
--- a/classes/class-paysoncheckout-for-woocommerce-gateway.php
+++ b/classes/class-paysoncheckout-for-woocommerce-gateway.php
@@ -49,6 +49,8 @@ class PaysonCheckout_For_WooCommerce_Gateway extends WC_Payment_Gateway {
 			'subscription_reactivation',
 			'subscription_amount_changes',
 			'subscription_date_changes',
+			'subscription_payment_method_change_customer',
+			'subscription_payment_method_change_admin',
 			'multiple_subscriptions',
 		);
 

--- a/classes/class-paysoncheckout-for-woocommerce-order-management.php
+++ b/classes/class-paysoncheckout-for-woocommerce-order-management.php
@@ -278,7 +278,7 @@ class PaysonCheckout_For_WooCommerce_Order_Management {
 
 			$refund_shipping = $refund_order->get_shipping_method();
 
-			if ( $payson_item['name'] === $refund_shipping ) {
+			if ( html_entity_decode( $payson_item['name'] ) === html_entity_decode( $refund_shipping ) ) {
 				$shipping_total = $refund_order->get_shipping_total();
 				$shipping_tax   = $refund_order->get_shipping_tax();
 

--- a/languages/woocommerce-gateway-paysoncheckout.pot
+++ b/languages/woocommerce-gateway-paysoncheckout.pot
@@ -36,11 +36,11 @@ msgstr ""
 msgstr ""
 
 #. translators: %s is an error message either from WordPress or Payson.
-#: ../classes/class-paysoncheckout-for-woocommerce-gateway.php:179
+#: ../classes/class-paysoncheckout-for-woocommerce-gateway.php:181
 msgid "The Payson order could not be retrieved: %s"
 msgstr ""
 
-#: ../classes/class-paysoncheckout-for-woocommerce-gateway.php:191
+#: ../classes/class-paysoncheckout-for-woocommerce-gateway.php:193
 msgid "It seems like the WooCommerce and Payson total amount differs. Please, try again."
 msgstr ""
 

--- a/paysoncheckout-for-woocommerce.php
+++ b/paysoncheckout-for-woocommerce.php
@@ -3,7 +3,7 @@
  * Plugin Name:     PaysonCheckout for WooCommerce
  * Plugin URI:      http://krokedil.com/
  * Description:     Provides a PaysonCheckout payment gateway for WooCommerce.
- * Version:         3.6.0
+ * Version:         3.6.1
  * Author:          Krokedil
  * Author URI:      http://krokedil.com/
  * Developer:       Krokedil
@@ -26,7 +26,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // Define plugin constants.
-define( 'PAYSONCHECKOUT_VERSION', '3.6.0' );
+define( 'PAYSONCHECKOUT_VERSION', '3.6.1' );
 define( 'PAYSONCHECKOUT_URL', untrailingslashit( plugins_url( '/', __FILE__ ) ) );
 define( 'PAYSONCHECKOUT_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'PAYSONCHECKOUT_LIVE_ENV', 'https://api.payson.se/2.0/' );

--- a/readme.txt
+++ b/readme.txt
@@ -37,6 +37,10 @@ More information on how to get started can be found in the [plugin documentation
 
 
 == CHANGELOG ==
+= 2023.08.29    - version 3.6.1 =
+* Fix           - Fixed an issue where a string comparison failed due to HTML entities in the item name.
+* Fix           - Revert changes from previous update that prevented renewal of failed subscriptions.
+
 = 2023.08.28    - version 3.6.0 =
 * Feature       - Added supports for multiple checkout layouts.
 * Fix           - Fixed an issue where the customer could not pay for a subscription through their account page.


### PR DESCRIPTION
* Fix           - Fixed an issue where a string comparison failed due to HTML entities in the item name.
* Fix           - Revert changes from previous update that prevented renewal of failed subscriptions.