### PR TITLE
wc_get_log_file_path deprecated without replacement

### DIFF
--- a/includes/paysoncheckout-for-woocommerce-form-fields.php
+++ b/includes/paysoncheckout-for-woocommerce-form-fields.php
@@ -102,7 +102,7 @@ $settings = array(
 		'type'        => 'checkbox',
 		'label'       => __( 'Enable logging', 'woocommerce-gateway-paysoncheckout' ),
 		'default'     => 'no',
-		'description' => sprintf( __( 'Log ' . $this->method_title . ' events in <code>%s</code>', 'woocommerce-gateway-paysoncheckout' ), wc_get_log_file_path( 'paysoncheckout' ) ), // phpcs:ignore
+		'description' => sprintf( __( 'You can find the log file <a href="%s">here</a>.', 'woocommerce-gateway-paysoncheckout' ), admin_url('admin.php?page=wc-status&tab=logs')), // phpcs:ignore
 	),
 );
 


### PR DESCRIPTION
The `wc_get_log_file_path` function is deprecated since version 8.6.0 without any replacement (see https://github.com/woocommerce/woocommerce/discussions/44369).

[CU task.](https://app.clickup.com/t/8694cczn4)