### PR TITLE
Move from WP Scheduler to Action Scheduler

### DIFF
--- a/classes/class-paysoncheckout-for-woocommerce-callbacks.php
+++ b/classes/class-paysoncheckout-for-woocommerce-callbacks.php
@@ -66,16 +66,21 @@ class PaysonCheckout_For_WooCommerce_Callbacks {
 		PaysonCheckout_For_WooCommerce_Logger::log( 'Notification Listener hit: ' . wp_json_encode( $_GET ) . ' URL: ' . wc_get_var( $_SERVER['REQUEST_URI'] ) );
 		$payson_order = pco_wc_get_order( $payment_id, $subscription );
 
+		$status = 'HTTP/1.1 404 Not Found';
 		if ( isset( $payment_id ) ) {
 			if ( is_wp_error( $payson_order ) ) {
 				PaysonCheckout_For_WooCommerce_Logger::log( 'Could not get order in notification callback. Payment ID: ' . $payment_id . 'Is subscription order: ' . $subscription );
 			} else {
-				if ( 'readyToShip' === $payson_order['status'] || 'customerSubscribed' === $payson_order['status'] ) {
+				$order = pco_get_order_by_payson_id( $payment_id );
+				if ( ! empty( $order ) && ( 'readyToShip' === $payson_order['status'] || 'customerSubscribed' === $payson_order['status'] ) ) {
 					$this->maybe_schedule_callback( $payment_id );
+					$status = 'HTTP/1.1 200 OK';
 				}
-				header( 'HTTP/1.1 200 OK' );
 			}
 		}
+
+		header( $status );
+		exit;
 	}
 
 	/**

--- a/classes/class-paysoncheckout-for-woocommerce-logger.php
+++ b/classes/class-paysoncheckout-for-woocommerce-logger.php
@@ -91,6 +91,10 @@ class PaysonCheckout_For_WooCommerce_Logger {
 			),
 			'timestamp'      => date( 'Y-m-d H:i:s' ),
 			'plugin_version' => PAYSONCHECKOUT_VERSION,
+			'php_version'    => phpversion(),
+			'wc_version'     => WC()->version,
+			'wp_version'     => get_bloginfo( 'version' ),
+			'user_agent'     => wc_get_user_agent(),
 			'stacktrace'     => self::get_stack(),
 		);
 	}


### PR DESCRIPTION

- move from WP schedule to Action schedule.
- filter input before access `$_GET`.
- log when a callback is received. This should make it easier to know whether we received a callback at all.
- log user agent, WC, WP and PHP versions.

https://app.clickup.com/t/869368uz3