### PR TITLE
Update nonces in case the customer has been signed in

### DIFF
--- a/assets/js/pco_checkout.js
+++ b/assets/js/pco_checkout.js
@@ -423,6 +423,10 @@ jQuery( function ( $ ) {
                 dataType: "json",
                 success: function ( data ) {
                     try {
+                        if (data.nonce) {
+                            pco_wc.updateNonce(data.nonce)
+                        }
+
                         if ( "success" === data.result ) {
                             pco_wc.logToFile(
                                 'Successfully placed order. Sending "paymentInitiationVerified" to Payson',
@@ -471,6 +475,21 @@ jQuery( function ( $ ) {
                     nonce: pco_wc_params.log_to_file_nonce,
                 },
             } )
+        },
+
+        /**
+         * Update the nonce values.
+         * 
+         * This is required when a guest user is logged in and the nonce values are updated since the nonce is associated with the user ID (0 for guests). 
+         * 
+         * @param {object} nonce An object containing the new nonce values.
+         */
+        updateNonce: function (nonce) {
+            for (const key in nonce) {
+                if (key in pco_wc_params) {
+                    pco_wc_params[key] = nonce[key]
+                }
+            }
         },
 
         /*

--- a/classes/class-paysoncheckout-for-woocommerce-gateway.php
+++ b/classes/class-paysoncheckout-for-woocommerce-gateway.php
@@ -171,6 +171,14 @@ class PaysonCheckout_For_WooCommerce_Gateway extends WC_Payment_Gateway {
 	 * @return array|bool
 	 */
 	public function process_payment( $order_id ) {
+		$nonce = array(
+			'address_changed_nonce'       => wp_create_nonce( 'pco_wc_address_changed' ),
+			'update_order_nonce'          => wp_create_nonce( 'pco_wc_update_checkout' ),
+			'change_payment_method_nonce' => wp_create_nonce( 'pco_wc_change_payment_method' ),
+			'get_order_nonce'             => wp_create_nonce( 'pco_wc_get_order' ),
+			'log_to_file_nonce'           => wp_create_nonce( 'pco_wc_log_js' ),
+		);
+
 		$order           = wc_get_order( $order_id );
 		$is_subscription = PaysonCheckout_For_WooCommerce_Subscriptions::order_has_subscription( $order );
 		if ( $is_subscription && PaysonCheckout_For_WooCommerce_Subscriptions::is_change_payment_method() ) {
@@ -184,6 +192,7 @@ class PaysonCheckout_For_WooCommerce_Gateway extends WC_Payment_Gateway {
 					),
 					$order->get_checkout_payment_url( true )
 				),
+				'nonce'    => $nonce,
 			);
 		}
 
@@ -199,6 +208,7 @@ class PaysonCheckout_For_WooCommerce_Gateway extends WC_Payment_Gateway {
 
 		return array(
 			'result' => 'success',
+			'nonce'  => $nonce,
 		);
 	}
 


### PR DESCRIPTION
Since the nonce is associated with the user ID, when a guest user (ID = 0) is signed in during the checkout, the nonce will become invalid, resulting in all AJAX requests failing validation. For this reason, we need to update the nonce, and since signing in is handled by Woo when `process_payment` is triggered, we send the nonce to the client in the same function.

- send updated nonce in `process_payment`.

https://app.clickup.com/t/8695ek7gb