### PR TITLE
Tweak the post purchase logic, if customer is not redirected correctly after purchase, to reliably save the Payson purchase ID to the order

### DIFF
--- a/includes/paysoncheckout-for-woocommerce-functions.php
+++ b/includes/paysoncheckout-for-woocommerce-functions.php
@@ -130,7 +130,7 @@ function pco_wc_maybe_create_payson_order( $subscription = false ) {
 			);
 
 			if ( count( $order ) > 0 ) {
-
+				// Redirect the customer and set the order key and payson payment id so that the order can be confirmed.
 				wp_safe_redirect(
 					add_query_arg(
 						array(
@@ -141,8 +141,6 @@ function pco_wc_maybe_create_payson_order( $subscription = false ) {
 						$order[0]->get_checkout_order_received_url()
 					)
 				);
-
-				pco_confirm_payson_order( WC()->session->get( 'payson_payment_id' ), $order[0]->get_id() );
 				exit;
 			}
 		}


### PR DESCRIPTION
* Correct the post-purchase redirection logic to reliably save the Payson purchase ID to the order if the initial redirect fails.