### PR TITLE
Version 3.9.2

### DIFF
--- a/classes/class-paysoncheckout-for-woocommerce-ajax.php
+++ b/classes/class-paysoncheckout-for-woocommerce-ajax.php
@@ -276,14 +276,20 @@ class PaysonCheckout_For_WooCommerce_AJAX extends WC_AJAX {
 	 * @return void
 	 */
 	public static function pco_wc_log_js() {
-		$nonce = isset( $_POST['nonce'] ) ? sanitize_key( $_POST['nonce'] ) : '';
-		if ( ! wp_verify_nonce( $nonce, 'pco_wc_log_js' ) ) {
-			wp_send_json_error( 'bad_nonce' );
-			exit;
-		}
-		$posted_message    = isset( $_POST['message'] ) ? sanitize_text_field( wp_unslash( $_POST['message'] ) ) : '';
+		check_ajax_referer( 'pco_wc_log_js', 'nonce' );
 		$payson_payment_id = WC()->session->get( 'payson_payment_id' );
-		$message           = "Frontend JS $payson_payment_id: $posted_message";
+
+		// Get the content size of the request.
+		$post_size = (int) $_SERVER['CONTENT_LENGTH'] ?? 0;
+
+		// If the post data is too long, log an error message and return.
+		if ( $post_size > 1024 ) {
+			PaysonCheckout_For_WooCommerce_Logger::log( "Frontend JS $payson_payment_id: message too long and can't be logged." );
+			wp_send_json_success(); // Return success to not stop anything in the frontend if this happens.
+		}
+
+		$posted_message = filter_input( INPUT_POST, 'message', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
+		$message        = "Frontend JS $payson_payment_id: $posted_message";
 		PaysonCheckout_For_WooCommerce_Logger::log( $message );
 		wp_send_json_success();
 	}

--- a/includes/paysoncheckout-for-woocommerce-functions.php
+++ b/includes/paysoncheckout-for-woocommerce-functions.php
@@ -130,7 +130,7 @@ function pco_wc_maybe_create_payson_order( $subscription = false ) {
 			);
 
 			if ( count( $order ) > 0 ) {
-
+				// Redirect the customer and set the order key and payson payment id so that the order can be confirmed.
 				wp_safe_redirect(
 					add_query_arg(
 						array(
@@ -141,8 +141,6 @@ function pco_wc_maybe_create_payson_order( $subscription = false ) {
 						$order[0]->get_checkout_order_received_url()
 					)
 				);
-
-				pco_confirm_payson_order( WC()->session->get( 'payson_payment_id' ), $order[0]->get_id() );
 				exit;
 			}
 		}

--- a/paysoncheckout-for-woocommerce.php
+++ b/paysoncheckout-for-woocommerce.php
@@ -3,7 +3,7 @@
  * Plugin Name:     PaysonCheckout for WooCommerce
  * Plugin URI:      http://krokedil.com/
  * Description:     Provides a PaysonCheckout payment gateway for WooCommerce.
- * Version:         3.9.1
+ * Version:         3.9.2
  * Author:          Krokedil
  * Author URI:      http://krokedil.com/
  * Developer:       Krokedil
@@ -11,10 +11,10 @@
  * Text Domain:     woocommerce-gateway-paysoncheckout
  * Domain Path:     /languages
  *
- * WC requires at least: 4.0
- * WC tested up to: 9.5.0
+ * WC requires at least: 5.6.0
+ * WC tested up to: 9.8.2
  *
- * Copyright:       © 2016-2024 Krokedil.
+ * Copyright:       © 2016-2025 Krokedil.
  * License:         GNU General Public License v3.0
  * License URI:     http://www.gnu.org/licenses/gpl-3.0.html
  *
@@ -26,7 +26,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // Define plugin constants.
-define( 'PAYSONCHECKOUT_VERSION', '3.9.1' );
+define( 'PAYSONCHECKOUT_VERSION', '3.9.2' );
 define( 'PAYSONCHECKOUT_URL', untrailingslashit( plugins_url( '/', __FILE__ ) ) );
 define( 'PAYSONCHECKOUT_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'PAYSONCHECKOUT_LIVE_ENV', 'https://api.payson.se/2.0/' );

--- a/readme.txt
+++ b/readme.txt
@@ -1,15 +1,15 @@
 === PaysonCheckout for WooCommerce ===
 Contributors: krokedil, niklashogefjord
 Tags: ecommerce, e-commerce, woocommerce, payson, paysoncheckout2.0
-Requires at least: 4.5
-Tested up to: 6.7.1
-Requires PHP: 7.0
-WC requires at least: 4.0.0
-WC tested up to: 9.5.0
+Requires at least: 5.0
+Tested up to: 6.8
+Requires PHP: 7.4
+WC requires at least: 5.6.0
+WC tested up to: 9.8.2
 
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
-Stable tag: trunk
+Stable tag: 3.9.2
 
 PaysonCheckout for WooCommerce is a plugin that extends WooCommerce, allowing you to take payments via Payson.
 
@@ -38,6 +38,10 @@ More information on how to get started can be found in the [plugin documentation
 
 
 == CHANGELOG ==
+= 2025.04.30    - version 3.9.2 =
+* Fix			- Tweak the post purchase logic, if customer is not redirected correctly after purchase, to reliably save the Payson purchase ID to the order.
+* Fix           - Limit the max size of a log message from the frontend to 1000 to prevent large logs from being created.
+
 = 2025.02.17    - version 3.9.1 =
 * Tweak         - Added filter to set request timeout for API calls.
 * Tweak         - Added logging on order confirmation.


### PR DESCRIPTION
* Fix	  - Tweak the post purchase logic, if customer is not redirected correctly after purchase, to reliably save the Payson purchase ID to the order.
* Fix - Limit the max size of a log message from the frontend to 1000 to prevent large logs from being created.